### PR TITLE
Scoutnets kårid, förifyllt?

### DIFF
--- a/templates/updatefromscoutnetform.html
+++ b/templates/updatefromscoutnetform.html
@@ -9,7 +9,7 @@
 <fieldset>
 	<div class="form-group">
 		<label for="groupid">Scoutnets kårid:</label>
-		<input type="text" name="groupid" id="groupid" value="1137" class="form-control"/>
+		<input type="text" name="groupid" id="groupid" value="" class="form-control"/>
 	</div>
 	<div class="form-group">
 		<label for="groupid">API nyckel:</label>


### PR DESCRIPTION
Fältet "Scoutnets kårid" är alltid förifyllt med 1137.

Hade varit trevligt om det var rätt kår, 
men nu är det bara förvirrande, då jag antog att det var rätt kårid.
Så bättra att tömma fältet.