### PR TITLE
Try to solve Issue 60, z-index conflicts

### DIFF
--- a/templates/troop.html
+++ b/templates/troop.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {% block main %}
 <div class="table-responsive">
-	<table id="maintable" class="table table-striped display nowrap">
+	<table id="maintable" class="table table-striped display nowrap" style="position: relative; z-index: 0;">
 	  <thead>
 		<tr>
 			<th class="troopnames">{{semestername}}<br/><span class="heading">{{heading}}</span></th>


### PR DESCRIPTION
The patrull-inputs and the table-headers-overlays are currently siblings in the z-index tree.
By putting one of the inputs parents, in this case the table-tag, at a z-index, it becomse the sibling to the table-headers, and the input as a child of the table, is on another level of the z-index tree, and can't endup above the table-headers.